### PR TITLE
Add 'nunjucks' and 'Nunjucks' as fileTypes. Capitalize name in description.

### DIFF
--- a/grammars/html (nunjucks templates).cson
+++ b/grammars/html (nunjucks templates).cson
@@ -1,9 +1,11 @@
 'fileTypes': [
+  'nunjucks'
+  'Nunjucks'
 ]
 'firstLineMatch': '^{% extends ["\'][^"\']+["\'] %}'
 'foldingStartMarker': '(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))'
 'foldingStopMarker': '(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})'
-'name': 'HTML (nunjucks Templates)'
+'name': 'HTML (Nunjucks Templates)'
 'patterns': [
   {
     'include': 'source.nunjucks'


### PR DESCRIPTION
Add 'nunjucks' and 'Nunjucks' to the `fileTypes` key of 'html (nunjucks templates).cson' so Atom's grammar selector will associate these files automatically. Fix capitalization in the `name` of the grammar.