### PR TITLE
Pattern for raw tags now works with '-' for whitespace control

### DIFF
--- a/grammars/nunjucks templates.cson
+++ b/grammars/nunjucks templates.cson
@@ -4,7 +4,7 @@
 'name': 'Nunjucks Templates'
 'patterns': [
   {
-    'begin': '({%)\\s*(raw)\\s*(%})'
+    'begin': '({%-?)\\s*(raw)\\s*(-?%})'
     'captures':
       '1':
         'name': 'entity.other.nunjucks.delimiter.tag'
@@ -12,7 +12,7 @@
         'name': 'keyword.control.nunjucks'
       '3':
         'name': 'entity.other.nunjucks.delimiter.tag'
-    'end': '({%)\\s*(endraw)\\s*(%})'
+    'end': '({%-?)\\s*(endraw)\\s*(-?%})'
     'name': 'comment.block.nunjucks.raw'
   }
   {


### PR DESCRIPTION
This fixes a bug where the `-` character used to trim leading/trailing whitespace caused the pattern used to find `{% raw %}` tags to not find it anymore. I added `-?` to the start and end patterns just like what has been done to capture them in other patterns.

**Before:**
![peek 2017-09-25 19-20](https://user-images.githubusercontent.com/3003251/30824324-1602c89e-a227-11e7-8857-71211030eabb.gif)

**After:**
![peek 2017-09-25 19-21](https://user-images.githubusercontent.com/3003251/30824333-200c07f6-a227-11e7-9775-1a363704dcc2.gif)

